### PR TITLE
Initializing `clients` both on the server and on the client

### DIFF
--- a/client/src/app/clients/page.tsx
+++ b/client/src/app/clients/page.tsx
@@ -1,5 +1,7 @@
+import ClientSection from '@/components/ClientSection';
+
 const ClientsPage = () => {
-  return <div>ClientsPage</div>;
+  return <ClientSection />;
 };
 
 export default ClientsPage;

--- a/client/src/app/invoices/page.tsx
+++ b/client/src/app/invoices/page.tsx
@@ -1,11 +1,7 @@
 import InvoiceTable from '@/components/InvoiceTable';
 
 const InvoicesPage = () => {
-  return (
-    <section>
-      <InvoiceTable />
-    </section>
-  );
+  return <InvoiceTable />;
 };
 
 export default InvoicesPage;

--- a/client/src/components/AddNewClientModal.tsx
+++ b/client/src/components/AddNewClientModal.tsx
@@ -1,0 +1,98 @@
+import {
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Select,
+  SelectItem,
+} from '@nextui-org/react';
+import { ChangeEvent, useState } from 'react';
+
+import { ClientModel } from '@/types/models/client';
+import { InvoicePartyBusinessType } from '@/types/models/invoice';
+import { capitalize } from '@/utils';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const clientBusinessTypes: Array<InvoicePartyBusinessType> = [
+  'business',
+  'individual',
+];
+
+type ClientFormData = Record<keyof Omit<ClientModel, 'id' | 'type'>, string>;
+
+const AddNewClientModal = ({ isOpen, onClose }: Props) => {
+  const [clientData, setClientData] = useState<ClientFormData>({
+    address: '',
+    businessNumber: '',
+    businessType: '',
+    email: '',
+    name: '',
+  });
+
+  const handleChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+    field: keyof Omit<ClientModel, 'id' | 'type'>
+  ) => {
+    setClientData((prev) => ({ ...prev, [field]: event.target.value }));
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalContent>
+        <ModalHeader>Add New Client</ModalHeader>
+        <ModalBody>
+          <Input
+            onChange={(event) => handleChange(event, 'name')}
+            type='text'
+            label='Name'
+            variant='bordered'
+          />
+          <Select
+            onChange={(event) => handleChange(event, 'businessType')}
+            label='Business Type'
+            variant='bordered'
+          >
+            {clientBusinessTypes.map((type) => (
+              <SelectItem key={type}>{capitalize(type)}</SelectItem>
+            ))}
+          </Select>
+          <Input
+            onChange={(event) => handleChange(event, 'businessNumber')}
+            type='text'
+            label='Business Number'
+            variant='bordered'
+          />
+          <Input
+            onChange={(event) => handleChange(event, 'address')}
+            type='text'
+            label='Address'
+            variant='bordered'
+          />
+          <Input
+            onChange={(event) => handleChange(event, 'email')}
+            type='email'
+            label='Email'
+            variant='bordered'
+          />
+        </ModalBody>
+        <ModalFooter>
+          <Button color='danger' variant='light' onPress={onClose}>
+            Cancel
+          </Button>
+          <Button color='secondary' onPress={onClose}>
+            Save
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default AddNewClientModal;

--- a/client/src/components/ClientSection.tsx
+++ b/client/src/components/ClientSection.tsx
@@ -1,0 +1,37 @@
+import { ClientModel } from '@/types/models/client';
+
+import InvoicePartyCard from './InvoicePartyCard';
+
+export const testSender: ClientModel = {
+  id: 1,
+  address: '21 Jump St.',
+  businessNumber: '123456789',
+  businessType: 'business',
+  firstName: 'John',
+  lastName: 'Doe',
+  type: 'receiver',
+};
+
+const clients = [testSender, testSender, testSender, testSender, testSender];
+
+const ClientSection = () => {
+  return (
+    <section>
+      <div className='grid gap-2 grid-cols-1 sm:grid-cols-2'>
+        {clients.map((client) => (
+          <InvoicePartyCard
+            key={client.id}
+            type='receiver'
+            address={client.address}
+            businessNumber={client.businessNumber}
+            businessType={client.businessType}
+            firstName={client.firstName}
+            lastName={client.lastName}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default ClientSection;

--- a/client/src/components/ClientSection.tsx
+++ b/client/src/components/ClientSection.tsx
@@ -1,35 +1,81 @@
+'use client';
+
+import { Spinner } from '@nextui-org/react';
+import { ChangeEvent, useState } from 'react';
+
+import useGetClients from '@/hooks/useGetClients';
 import { ClientModel } from '@/types/models/client';
 
+import ClientSectionBottomContent from './ClientSectionBottomContent';
+import ClientSectionTopContent from './ClientSectionTopContent';
 import InvoicePartyCard from './InvoicePartyCard';
 
-export const testSender: ClientModel = {
-  id: 1,
-  address: '21 Jump St.',
-  businessNumber: '123456789',
-  businessType: 'business',
-  firstName: 'John',
-  lastName: 'Doe',
-  type: 'receiver',
-};
-
-const clients = [testSender, testSender, testSender, testSender, testSender];
+const PER_PAGE = 8;
 
 const ClientSection = () => {
-  return (
-    <section>
-      <div className='grid gap-2 grid-cols-1 sm:grid-cols-2'>
-        {clients.map((client) => (
-          <InvoicePartyCard
-            key={client.id}
-            type='receiver'
-            address={client.address}
-            businessNumber={client.businessNumber}
-            businessType={client.businessType}
-            firstName={client.firstName}
-            lastName={client.lastName}
-          />
-        ))}
+  const { clients, isClientsLoading } = useGetClients();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [page, setPage] = useState(1);
+
+  const handleSearch = (event: ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(event.target.value);
+    setPage(1);
+  };
+
+  const renderClient = (client: ClientModel, index: number) => {
+    const { name } = client;
+
+    const normalizedName = name.toLowerCase();
+    const normalizedSearchTerm = searchTerm.toLowerCase();
+    const isItemInCurrentPageRange =
+      index >= (page - 1) * PER_PAGE && index < page * PER_PAGE;
+
+    if (!normalizedName.includes(normalizedSearchTerm)) return;
+
+    if (!isItemInCurrentPageRange) return;
+
+    return (
+      <InvoicePartyCard
+        key={client.id}
+        type='receiver'
+        address={client.address}
+        businessNumber={client.businessNumber}
+        businessType={client.businessType}
+        name={client.name}
+      />
+    );
+  };
+
+  const renderSectionContent = () => {
+    if (isClientsLoading)
+      return (
+        <div className='min-h-[480px] h-0'>
+          <Spinner color='secondary' className='m-auto w-full h-full' />
+        </div>
+      );
+
+    return (
+      <div className='min-h-[480px]'>
+        <div className='grid gap-4 grid-cols-1 sm:grid-cols-2'>
+          {clients?.map((client, index) => renderClient(client, index))}
+        </div>
       </div>
+    );
+  };
+
+  return (
+    <section className='flex flex-col gap-4'>
+      <ClientSectionTopContent
+        clients={clients}
+        searchTerm={searchTerm}
+        onSearch={handleSearch}
+      />
+      {renderSectionContent()}
+      <ClientSectionBottomContent
+        page={page}
+        setPage={setPage}
+        clientsLength={clients?.length}
+      />
     </section>
   );
 };

--- a/client/src/components/ClientSectionBottomContent.tsx
+++ b/client/src/components/ClientSectionBottomContent.tsx
@@ -1,0 +1,50 @@
+import { Pagination } from '@nextui-org/react';
+import { Dispatch, SetStateAction } from 'react';
+
+const PER_PAGE = 8;
+const INITIAL_PAGE = 1;
+
+type Props = {
+  clientsLength: number | undefined;
+  page: number;
+  setPage: Dispatch<SetStateAction<number>>;
+};
+
+const ClientSectionBottomContent = ({
+  clientsLength,
+  page,
+  setPage,
+}: Props) => {
+  const pages = clientsLength
+    ? Math.ceil(clientsLength / PER_PAGE)
+    : INITIAL_PAGE;
+
+  const onNextPage = () => {
+    if (page < pages) {
+      setPage(page + 1);
+    }
+  };
+
+  const onPreviousPage = () => {
+    if (page > 1) {
+      setPage(page - 1);
+    }
+  };
+
+  return (
+    <div className='w-full mt-2'>
+      <Pagination
+        isCompact
+        showControls
+        color='secondary'
+        total={pages}
+        page={page}
+        className='flex justify-center'
+        onChange={setPage}
+        isDisabled={!clientsLength}
+      />
+    </div>
+  );
+};
+
+export default ClientSectionBottomContent;

--- a/client/src/components/ClientSectionTopContent.tsx
+++ b/client/src/components/ClientSectionTopContent.tsx
@@ -7,10 +7,12 @@ import {
   DropdownMenu,
   DropdownTrigger,
   Input,
+  Selection,
 } from '@nextui-org/react';
 import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react';
 
 import { ClientModel } from '@/types/models/client';
+import { InvoicePartyBusinessType } from '@/types/models/invoice';
 import { capitalize } from '@/utils';
 
 import AddNewClientModal from './AddNewClientModal';
@@ -18,15 +20,25 @@ import { ChevronDownIcon } from './icons/ChevronDownIcon';
 import { PlusIcon } from './icons/PlusIcon';
 import SearchIcon from './icons/SearchIcon';
 
-const filters = ['name'];
+const filters = ['business', 'individual'];
 
 type Props = {
   clients: Array<ClientModel> | undefined;
   searchTerm: string;
   onSearch: (event: ChangeEvent<HTMLInputElement>) => void;
+  onClear: () => void;
+  typeFilters: Set<InvoicePartyBusinessType>;
+  setTypeFilters: Dispatch<SetStateAction<Set<InvoicePartyBusinessType>>>;
 };
 
-const ClientSectionTopContent = ({ clients, searchTerm, onSearch }: Props) => {
+const ClientSectionTopContent = ({
+  clients,
+  searchTerm,
+  onSearch,
+  onClear,
+  typeFilters,
+  setTypeFilters,
+}: Props) => {
   const [isAddNewClientModalOpen, setIsAddNewClientModalOpen] = useState(false);
 
   const handleAddNewClient = () => {
@@ -36,6 +48,33 @@ const ClientSectionTopContent = ({ clients, searchTerm, onSearch }: Props) => {
   const handleCloseAddNewClientModal = () => {
     setIsAddNewClientModalOpen(false);
   };
+
+  const renderTypeFilterSelect = () => (
+    <Dropdown>
+      <DropdownTrigger className='hidden sm:flex'>
+        <Button
+          endContent={<ChevronDownIcon className='text-small' />}
+          variant='flat'
+        >
+          Type
+        </Button>
+      </DropdownTrigger>
+      <DropdownMenu
+        disallowEmptySelection
+        aria-label='Table Columns'
+        closeOnSelect={false}
+        selectionMode='multiple'
+        selectedKeys={typeFilters}
+        onSelectionChange={setTypeFilters as (keys: Selection) => any}
+      >
+        {filters.map((filter) => (
+          <DropdownItem key={filter} className='capitalize'>
+            {capitalize(filter)}
+          </DropdownItem>
+        ))}
+      </DropdownMenu>
+    </Dropdown>
+  );
 
   return (
     <>
@@ -48,54 +87,10 @@ const ClientSectionTopContent = ({ clients, searchTerm, onSearch }: Props) => {
             startContent={<SearchIcon width={16} height={16} />}
             value={searchTerm}
             onChange={onSearch}
+            onClear={onClear}
           />
           <div className='flex gap-3'>
-            <Dropdown>
-              <DropdownTrigger className='hidden sm:flex'>
-                <Button
-                  endContent={<ChevronDownIcon className='text-small' />}
-                  variant='flat'
-                >
-                  Status
-                </Button>
-              </DropdownTrigger>
-              <DropdownMenu
-                disallowEmptySelection
-                aria-label='Table Columns'
-                closeOnSelect={false}
-                selectionMode='multiple'
-              >
-                {filters.map((filter) => (
-                  <DropdownItem key={filter} className='capitalize'>
-                    {capitalize(filter)}
-                  </DropdownItem>
-                ))}
-              </DropdownMenu>
-            </Dropdown>
-            {/* <Dropdown>
-            <DropdownTrigger className='hidden sm:flex'>
-              <Button
-                endContent={<ChevronDownIcon className='text-small' />}
-                variant='flat'
-              >
-                Columns
-              </Button>
-            </DropdownTrigger>
-            {/* <DropdownMenu
-              disallowEmptySelection
-              aria-label='Table Columns'
-              closeOnSelect={false}
-
-              selectionMode='multiple'
-
-            >
-              {columns.map((column) => (
-                <DropdownItem key={column.uid} className='capitalize'>
-                  {capitalize(column.name)}
-                </DropdownItem>
-              ))}
-            </DropdownMenu>
-          </Dropdown> */}
+            {renderTypeFilterSelect()}
             <Button
               color='secondary'
               endContent={<PlusIcon width={16} height={16} />}

--- a/client/src/components/ClientSectionTopContent.tsx
+++ b/client/src/components/ClientSectionTopContent.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownTrigger,
+  Input,
+} from '@nextui-org/react';
+import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react';
+
+import { ClientModel } from '@/types/models/client';
+import { capitalize } from '@/utils';
+
+import AddNewClientModal from './AddNewClientModal';
+import { ChevronDownIcon } from './icons/ChevronDownIcon';
+import { PlusIcon } from './icons/PlusIcon';
+import SearchIcon from './icons/SearchIcon';
+
+const filters = ['name'];
+
+type Props = {
+  clients: Array<ClientModel> | undefined;
+  searchTerm: string;
+  onSearch: (event: ChangeEvent<HTMLInputElement>) => void;
+};
+
+const ClientSectionTopContent = ({ clients, searchTerm, onSearch }: Props) => {
+  const [isAddNewClientModalOpen, setIsAddNewClientModalOpen] = useState(false);
+
+  const handleAddNewClient = () => {
+    setIsAddNewClientModalOpen(true);
+  };
+
+  const handleCloseAddNewClientModal = () => {
+    setIsAddNewClientModalOpen(false);
+  };
+
+  return (
+    <>
+      <div className='flex flex-col gap-4'>
+        <div className='flex justify-between gap-3 items-end'>
+          <Input
+            isClearable
+            className='w-full sm:max-w-[44%]'
+            placeholder='Search by name...'
+            startContent={<SearchIcon width={16} height={16} />}
+            value={searchTerm}
+            onChange={onSearch}
+          />
+          <div className='flex gap-3'>
+            <Dropdown>
+              <DropdownTrigger className='hidden sm:flex'>
+                <Button
+                  endContent={<ChevronDownIcon className='text-small' />}
+                  variant='flat'
+                >
+                  Status
+                </Button>
+              </DropdownTrigger>
+              <DropdownMenu
+                disallowEmptySelection
+                aria-label='Table Columns'
+                closeOnSelect={false}
+                selectionMode='multiple'
+              >
+                {filters.map((filter) => (
+                  <DropdownItem key={filter} className='capitalize'>
+                    {capitalize(filter)}
+                  </DropdownItem>
+                ))}
+              </DropdownMenu>
+            </Dropdown>
+            {/* <Dropdown>
+            <DropdownTrigger className='hidden sm:flex'>
+              <Button
+                endContent={<ChevronDownIcon className='text-small' />}
+                variant='flat'
+              >
+                Columns
+              </Button>
+            </DropdownTrigger>
+            {/* <DropdownMenu
+              disallowEmptySelection
+              aria-label='Table Columns'
+              closeOnSelect={false}
+
+              selectionMode='multiple'
+
+            >
+              {columns.map((column) => (
+                <DropdownItem key={column.uid} className='capitalize'>
+                  {capitalize(column.name)}
+                </DropdownItem>
+              ))}
+            </DropdownMenu>
+          </Dropdown> */}
+            <Button
+              color='secondary'
+              endContent={<PlusIcon width={16} height={16} />}
+              onClick={handleAddNewClient}
+            >
+              Add New
+            </Button>
+          </div>
+        </div>
+        <div className='flex justify-between items-center'>
+          <span className='text-default-400 text-small'>
+            {clients
+              ? `Total ${clients.length} clients`
+              : 'No clients to display'}
+          </span>
+        </div>
+      </div>
+
+      <AddNewClientModal
+        isOpen={isAddNewClientModalOpen}
+        onClose={handleCloseAddNewClientModal}
+      />
+    </>
+  );
+};
+
+export default ClientSectionTopContent;

--- a/client/src/components/InvoicePartyCard.tsx
+++ b/client/src/components/InvoicePartyCard.tsx
@@ -1,0 +1,50 @@
+import { Card, CardBody, CardHeader } from '@nextui-org/react';
+
+import {
+  InvoicePartyBusinessType,
+  InvoicePartyType,
+} from '@/types/models/invoice';
+
+type Props = {
+  address: string;
+  businessNumber: string;
+  firstName: string;
+  lastName: string;
+  email?: string;
+  type: InvoicePartyType;
+  businessType: InvoicePartyBusinessType;
+  insideForm?: boolean;
+};
+
+const InvoicePartyCard = ({
+  address,
+  businessNumber,
+  firstName,
+  lastName,
+  type,
+  businessType,
+  email,
+  insideForm = false,
+}: Props) => {
+  const smallText = type === 'receiver' ? 'From:' : 'To:';
+
+  return (
+    <Card className='py-4'>
+      <CardHeader className='pb-0 pt-2  flex-col items-start'>
+        {insideForm && <small className='text-default-500'>{smallText}</small>}
+        <h4 className='font-bold text-large'>
+          {firstName} {lastName}
+        </h4>
+      </CardHeader>
+      <CardBody className='overflow-visible py-2'>
+        <p className='text-tiny uppercase font-bold'>
+          {businessType} No. {businessNumber}
+        </p>
+        <small className='text-default-500'>{address}</small>
+        {email && <small className='text-default-500'>{email}</small>}
+      </CardBody>
+    </Card>
+  );
+};
+
+export default InvoicePartyCard;

--- a/client/src/components/InvoicePartyCard.tsx
+++ b/client/src/components/InvoicePartyCard.tsx
@@ -1,40 +1,78 @@
-import { Card, CardBody, CardHeader } from '@nextui-org/react';
+'use client';
+
+import { Button, Card, CardBody, CardHeader } from '@nextui-org/react';
+import { ReactNode } from 'react';
 
 import {
   InvoicePartyBusinessType,
   InvoicePartyType,
 } from '@/types/models/invoice';
 
+import TrashIcon from './icons/TrashIcon';
+
 type Props = {
   address: string;
   businessNumber: string;
-  firstName: string;
-  lastName: string;
+  name: string;
   email?: string;
   type: InvoicePartyType;
   businessType: InvoicePartyBusinessType;
   insideForm?: boolean;
+  actions?: ReactNode;
 };
 
 const InvoicePartyCard = ({
   address,
   businessNumber,
-  firstName,
-  lastName,
+  name,
   type,
   businessType,
   email,
   insideForm = false,
+  actions,
 }: Props) => {
   const smallText = type === 'receiver' ? 'From:' : 'To:';
 
+  const handleEditClient = () => {
+    alert('editing');
+  };
+
+  const handleDeleteClient = () => {
+    alert('deletion');
+  };
+
+  const renderActions = () => (
+    <div className='absolute right-2 top-2 flex gap-1.5 z-10'>
+      {actions ? (
+        actions
+      ) : (
+        <>
+          <Button
+            className='min-w-unit-10 w-unit-16 h-unit-8 cursor-pointer'
+            variant='bordered'
+            onClick={handleEditClient}
+          >
+            Edit
+          </Button>
+          <Button
+            isIconOnly
+            variant='bordered'
+            color='danger'
+            className='min-w-unit-8 w-unit-8 h-unit-8 cursor-pointer'
+            onClick={handleDeleteClient}
+          >
+            <TrashIcon height={4} width={4} />
+          </Button>
+        </>
+      )}
+    </div>
+  );
+
   return (
-    <Card className='py-4'>
-      <CardHeader className='pb-0 pt-2  flex-col items-start'>
+    <Card className='p-2 relative'>
+      <CardHeader className='pb-0 flex-col items-start'>
         {insideForm && <small className='text-default-500'>{smallText}</small>}
-        <h4 className='font-bold text-large'>
-          {firstName} {lastName}
-        </h4>
+        <h4 className='font-bold text-large'>{name}</h4>
       </CardHeader>
       <CardBody className='overflow-visible py-2'>
         <p className='text-tiny uppercase font-bold'>
@@ -43,6 +81,7 @@ const InvoicePartyCard = ({
         <small className='text-default-500'>{address}</small>
         {email && <small className='text-default-500'>{email}</small>}
       </CardBody>
+      {renderActions()}
     </Card>
   );
 };

--- a/client/src/components/InvoiceTable.tsx
+++ b/client/src/components/InvoiceTable.tsx
@@ -71,7 +71,7 @@ const InvoiceTable = () => {
 
     if (hasSearchFilter) {
       filteredInvoices = filteredInvoices.filter((invoice) =>
-        invoice.id.toLowerCase().includes(filterValue.toLowerCase())
+        invoice.id.toString().toLowerCase().includes(filterValue.toLowerCase())
       );
     }
     if (

--- a/client/src/components/InvoiceTable.tsx
+++ b/client/src/components/InvoiceTable.tsx
@@ -160,7 +160,7 @@ const InvoiceTable = () => {
   );
 
   return (
-    <>
+    <section>
       <Table
         aria-label='Example table with custom cells, pagination and sorting'
         isHeaderSticky
@@ -211,7 +211,7 @@ const InvoiceTable = () => {
           invoiceData={currentInvoice}
         />
       )}
-    </>
+    </section>
   );
 };
 

--- a/client/src/components/InvoiceTable.tsx
+++ b/client/src/components/InvoiceTable.tsx
@@ -10,6 +10,7 @@ import {
   TableHeader,
   TableRow,
   useDisclosure,
+  Selection,
 } from '@nextui-org/react';
 import { Key, useCallback, useMemo, useState } from 'react';
 
@@ -174,8 +175,8 @@ const InvoiceTable = () => {
         sortDescriptor={sortDescriptor}
         topContent={topContent}
         topContentPlacement='outside'
-        onSelectionChange={setSelectedKeys as any}
-        onSortChange={setSortDescriptor as any}
+        onSelectionChange={setSelectedKeys as (keys: Selection) => any}
+        onSortChange={setSortDescriptor as (descriptor: SortDescriptor) => any}
       >
         <TableHeader columns={headerColumns}>
           {(column) => (

--- a/client/src/components/Pdf/Pdf.tsx
+++ b/client/src/components/Pdf/Pdf.tsx
@@ -17,14 +17,14 @@ const Pdf = ({ invoiceData }: Props) => {
     company,
     date,
     dueDate,
-    id,
+    invoiceId,
     receiver,
     sender,
     services,
     totalAmount,
   } = invoiceData;
 
-  const splitId = splitInvoiceId(id);
+  const splitId = splitInvoiceId(invoiceId);
   const series = splitId[0];
   const number = splitId[1];
 
@@ -43,9 +43,7 @@ const Pdf = ({ invoiceData }: Props) => {
       <View style={styles.row}>
         <View style={styles.leftColumn}>
           <Text style={styles.detailItemTitle}>Tiekėjas:</Text>
-          <Text style={styles.detailItem}>
-            {sender.firstName} {sender.lastName}
-          </Text>
+          <Text style={styles.detailItem}>{sender.name}</Text>
           <Text style={styles.detailItem}>
             Įmonės kodas: {sender.businessNumber}
           </Text>

--- a/client/src/components/icons/TrashIcon.jsx
+++ b/client/src/components/icons/TrashIcon.jsx
@@ -1,0 +1,18 @@
+const TrashIcon = ({ height, width }) => (
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    fill='none'
+    viewBox='0 0 24 24'
+    strokeWidth={1.5}
+    stroke='currentColor'
+    className={`w-${width} h-${height}`}
+  >
+    <path
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      d='m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0'
+    />
+  </svg>
+);
+
+export default TrashIcon;

--- a/client/src/constants/swrKeys.ts
+++ b/client/src/constants/swrKeys.ts
@@ -1,5 +1,6 @@
 const SWRKeys = {
   invoices: () => '/api/invoices',
+  clients: () => '/api/clients',
 };
 
 export default SWRKeys;

--- a/client/src/hooks/useGetClients.ts
+++ b/client/src/hooks/useGetClients.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import useSWR from 'swr';
+
+import { ClientModel } from '@/types/models/client';
+
+import SWRKeys from '../constants/swrKeys';
+
+const useGetClients = () => {
+  const { data, isLoading, mutate, error, isValidating } = useSWR<
+    Array<ClientModel>
+  >(SWRKeys.clients);
+
+  return useMemo(
+    () => ({
+      clients: data,
+      isClientsLoading: isLoading,
+      mutateClients: mutate,
+      clientsError: error,
+      clientsIsValidating: isValidating,
+    }),
+    [data, isLoading, mutate, error, isValidating]
+  );
+};
+
+export default useGetClients;

--- a/client/src/types/models/client.ts
+++ b/client/src/types/models/client.ts
@@ -1,0 +1,12 @@
+import { InvoicePartyBusinessType, InvoicePartyType } from './invoice';
+
+export type ClientModel = {
+  id: number;
+  firstName: string;
+  lastName: string;
+  type: InvoicePartyType;
+  businessType: InvoicePartyBusinessType;
+  businessNumber: string;
+  address: string;
+  email?: string;
+};

--- a/client/src/types/models/invoice.ts
+++ b/client/src/types/models/invoice.ts
@@ -3,8 +3,7 @@ export type InvoicePartyBusinessType = 'business' | 'individual';
 export type InvoicePartyType = 'sender' | 'receiver';
 
 export type InvoiceParty = {
-  firstName: string;
-  lastName: string;
+  name: string;
   businessType: string;
   businessNumber: string;
   address: string;
@@ -22,7 +21,8 @@ export type InvoiceService = {
 };
 
 export type InvoiceModel = {
-  id: string;
+  id: number;
+  invoiceId: string;
   date: string;
   company: string;
   sender: InvoiceParty;

--- a/client/src/types/models/invoice.ts
+++ b/client/src/types/models/invoice.ts
@@ -1,11 +1,18 @@
+export type InvoicePartyBusinessType = 'business' | 'individual';
+
+export type InvoicePartyType = 'sender' | 'receiver';
+
 export type InvoiceParty = {
   firstName: string;
   lastName: string;
-  type: string;
+  businessType: string;
   businessNumber: string;
   address: string;
   email?: string;
+  type: InvoicePartyType;
 };
+
+export type InvoiceStatus = 'paid' | 'pending' | 'canceled';
 
 export type InvoiceService = {
   description: string;
@@ -25,5 +32,3 @@ export type InvoiceModel = {
   services: Array<InvoiceService>;
   dueDate: string;
 };
-
-export type InvoiceStatus = 'paid' | 'pending' | 'canceled';

--- a/server/database/db.ts
+++ b/server/database/db.ts
@@ -1,0 +1,20 @@
+import postgres from 'postgres';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+let { PGHOST, PGDATABASE, PGUSER, PGPASSWORD } = process.env;
+
+const sql = postgres({
+  host: PGHOST,
+  database: PGDATABASE,
+  username: PGUSER,
+  password: PGPASSWORD,
+  port: 5432,
+  ssl: 'require',
+});
+
+export async function getPgVersion() {
+  const result = await sql`select version()`;
+  console.log(result[0]);
+}

--- a/server/database/invoice.ts
+++ b/server/database/invoice.ts
@@ -1,0 +1,7 @@
+import postgres from 'postgres';
+import sql from 'postgres';
+import { InvoiceModel } from '../src/types/models/invoice';
+
+// export const insertInvoiceData = (invoiceData: InvoiceModel) => {
+//
+// };

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "tsc && node dist/app.js",
-    "dev": "tsc && nodemon dist/app.js"
+    "dev": "tsc && nodemon src/app.ts"
   },
   "author": "rekodev",
   "license": "ISC",
@@ -18,6 +18,8 @@
   },
   "dependencies": {
     "@fastify/cors": "^9.0.1",
-    "fastify": "^4.26.2"
+    "fastify": "^4.26.2",
+    "postgres": "^3.4.4",
+    "ts-node": "^10.9.2"
   }
 }

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -11,6 +11,12 @@ dependencies:
   fastify:
     specifier: ^4.26.2
     version: 4.26.2
+  postgres:
+    specifier: ^3.4.4
+    version: 3.4.4
+  ts-node:
+    specifier: ^10.9.2
+    version: 10.9.2(@types/node@20.11.30)(typescript@5.4.3)
 
 devDependencies:
   '@types/node':
@@ -27,6 +33,13 @@ devDependencies:
     version: 5.4.3
 
 packages:
+
+  /@cspotcode/source-map-support@0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    dev: false
 
   /@fastify/ajv-compiler@3.5.0:
     resolution: {integrity: sha512-ebbEtlI7dxXF5ziNdr05mOY8NnDiPB1XvAlLHctRt/Rc+C3LCOVW5imUVX+mhvUhnNzmPBHewUkOFgGlCxgdAA==}
@@ -59,11 +72,42 @@ packages:
       fast-deep-equal: 3.1.3
     dev: false
 
+  /@jridgewell/resolve-uri@3.1.2:
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+    dev: false
+
+  /@jridgewell/sourcemap-codec@1.4.15:
+    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+    dev: false
+
+  /@jridgewell/trace-mapping@0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: false
+
+  /@tsconfig/node10@1.0.10:
+    resolution: {integrity: sha512-PiaIWIoPvO6qm6t114ropMCagj6YAF24j9OkCA2mJDXFnlionEwhsBCJ8yek4aib575BI3OkART/90WsgHgLWw==}
+    dev: false
+
+  /@tsconfig/node12@1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: false
+
+  /@tsconfig/node14@1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: false
+
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+    dev: false
+
   /@types/node@20.11.30:
     resolution: {integrity: sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==}
     dependencies:
       undici-types: 5.26.5
-    dev: true
 
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -78,6 +122,17 @@ packages:
 
   /abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+    dev: false
+
+  /acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
+  /acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
     dev: false
 
   /ajv-formats@2.1.1(ajv@8.12.0):
@@ -110,6 +165,10 @@ packages:
 
   /archy@1.0.0:
     resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
+    dev: false
+
+  /arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
     dev: false
 
   /atomic-sleep@1.0.0:
@@ -186,6 +245,10 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: false
+
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -197,6 +260,11 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 5.5.0
+
+  /diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+    dev: false
 
   /dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
@@ -386,6 +454,10 @@ packages:
     dependencies:
       yallist: 4.0.0
 
+  /make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: false
+
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -470,6 +542,11 @@ packages:
       safe-stable-stringify: 2.4.3
       sonic-boom: 3.8.0
       thread-stream: 2.4.1
+    dev: false
+
+  /postgres@3.4.4:
+    resolution: {integrity: sha512-IbyN+9KslkqcXa8AO9fxpk97PA4pzewvpi2B3Dwy9u4zpV32QicaEdgmF3eSQUzdRk7ttDHQejNgAEr4XoeH4A==}
+    engines: {node: '>=12'}
     dev: false
 
   /process-warning@3.0.0:
@@ -629,11 +706,41 @@ packages:
       nopt: 1.0.10
     dev: true
 
+  /ts-node@10.9.2(@types/node@20.11.30)(typescript@5.4.3):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.10
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.11.30
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.4.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: false
+
   /typescript@5.4.3:
     resolution: {integrity: sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /undefsafe@2.0.5:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
@@ -641,7 +748,6 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-    dev: true
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -649,5 +755,14 @@ packages:
       punycode: 2.3.1
     dev: false
 
+  /v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: false
+
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  /yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+    dev: false

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -4,6 +4,7 @@ import dotenv from 'dotenv';
 import cors from '@fastify/cors';
 
 import invoiceRoutes from './routes/invoice';
+import { getPgVersion } from '../database/db';
 
 dotenv.config();
 
@@ -12,6 +13,8 @@ const server = fastify();
 server.register(cors);
 
 server.register(invoiceRoutes);
+
+getPgVersion();
 
 server.listen({ port }, (err, address) => {
   if (err) {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,6 +5,7 @@ import cors from '@fastify/cors';
 
 import invoiceRoutes from './routes/invoice';
 import { getPgVersion } from '../database/db';
+import clientRoutes from './routes/client';
 
 dotenv.config();
 
@@ -13,6 +14,7 @@ const server = fastify();
 server.register(cors);
 
 server.register(invoiceRoutes);
+server.register(clientRoutes);
 
 getPgVersion();
 

--- a/server/src/controllers/client.ts
+++ b/server/src/controllers/client.ts
@@ -1,0 +1,24 @@
+import { clients } from '../data';
+import { ClientModel } from '../types/models/client';
+
+export const getClients = (req, reply) => {
+  reply.send(clients);
+};
+
+export const getClient = (req, reply) => {
+  const { id } = req.params;
+};
+
+export const postClient = (req, reply) => {
+  const { id, address, businessNumber, businessType, name, type, email } = <
+    ClientModel
+  >req.body;
+};
+
+export const updateClient = (req, reply) => {
+  const { id } = req.params;
+};
+
+export const deleteClient = (req, reply) => {
+  const { id } = req.params;
+};

--- a/server/src/data/index.ts
+++ b/server/src/data/index.ts
@@ -1,3 +1,4 @@
+import { ClientModel } from '../types/models/client';
 import {
   InvoiceModel,
   InvoiceParty,
@@ -7,8 +8,7 @@ import {
 export const testSender: InvoiceParty = {
   address: '21 Jump St.',
   businessNumber: '123456789',
-  firstName: 'John',
-  lastName: 'Doe',
+  name: 'John Doe',
   type: 'Irrelevant for now',
 };
 
@@ -201,5 +201,89 @@ export const invoices: Array<InvoiceModel> = [
     receiver: testReceiver,
     dueDate: '2024-03-26', // Example due date, adjust as necessary
     services: [testService], // Assuming this is an array of ser
+  },
+];
+
+export const clients: Array<ClientModel> = [
+  {
+    id: 1,
+    address: '21 Jump St.',
+    businessNumber: '123456789',
+    businessType: 'business',
+    name: 'John Doe',
+
+    type: 'receiver',
+  },
+  {
+    id: 2,
+    address: '47 Elm St.',
+    businessNumber: '987654321',
+    businessType: 'individual',
+    name: 'Jane',
+    type: 'receiver',
+  },
+  {
+    id: 3,
+    address: '84 Oak Ave.',
+    businessNumber: '192837465',
+    businessType: 'business',
+    name: 'Alice',
+    type: 'receiver',
+  },
+  {
+    id: 4,
+    address: '32 Maple Rd.',
+    businessNumber: '564738291',
+    businessType: 'individual',
+    name: 'Bob',
+    type: 'receiver',
+  },
+  {
+    id: 5,
+    address: '98 Pine St.',
+    businessNumber: '374829165',
+    businessType: 'business',
+    name: 'Charlie',
+    type: 'receiver',
+  },
+  {
+    id: 6,
+    address: '98 Pine St.',
+    businessNumber: '372359165',
+    businessType: 'business',
+    name: 'Charlize',
+    type: 'receiver',
+  },
+  {
+    id: 7,
+    address: '98 Pine St.',
+    businessNumber: '374829165',
+    businessType: 'business',
+    name: 'Charlie',
+    type: 'receiver',
+  },
+  {
+    id: 8,
+    address: '98 Pine St.',
+    businessNumber: '374829165',
+    businessType: 'business',
+    name: 'EDIGINO',
+    type: 'receiver',
+  },
+  {
+    id: 9,
+    address: '98 Pine St.',
+    businessNumber: '374829165',
+    businessType: 'business',
+    name: 'Charlie Hello',
+    type: 'receiver',
+  },
+  {
+    id: 10,
+    address: '98 Pine St.',
+    businessNumber: '374829165',
+    businessType: 'business',
+    name: 'Charlie Whatever',
+    type: 'receiver',
   },
 ];

--- a/server/src/data/index.ts
+++ b/server/src/data/index.ts
@@ -23,7 +23,8 @@ export const testService: InvoiceService = {
 
 export const invoices: Array<InvoiceModel> = [
   {
-    id: 'PRO123',
+    id: 1,
+    invoiceId: 'PRO123',
     date: '2024-03-24',
     company: 'Company 2',
     totalAmount: 300, // Assuming totalAmount corresponds to price
@@ -34,7 +35,8 @@ export const invoices: Array<InvoiceModel> = [
     services: [testService, testService], // Assuming this is an array of ser
   },
   {
-    id: 'PRO175923',
+    id: 2,
+    invoiceId: 'PRO175923',
     date: '2024-02-24',
     company: 'Company 2',
     totalAmount: 300, // Assuming totalAmount corresponds to price
@@ -45,7 +47,8 @@ export const invoices: Array<InvoiceModel> = [
     services: [testService], // Assuming this is an array of ser
   },
   {
-    id: 'PRO1853',
+    id: 3,
+    invoiceId: 'PRO1853',
     date: '2024-02-24',
     company: 'Company 2',
     totalAmount: 300, // Assuming totalAmount corresponds to price
@@ -56,7 +59,8 @@ export const invoices: Array<InvoiceModel> = [
     services: [testService], // Assuming this is an array of ser
   },
   {
-    id: 'PRO175',
+    id: 4,
+    invoiceId: 'PRO175',
     date: '2024-02-24',
     company: 'Company 2',
     totalAmount: 300, // Assuming totalAmount corresponds to price
@@ -67,7 +71,8 @@ export const invoices: Array<InvoiceModel> = [
     services: [testService], // Assuming this is an array of ser
   },
   {
-    id: 'PRO1245',
+    id: 5,
+    invoiceId: 'PRO1245',
     date: '2024-02-24',
     company: 'Company 2',
     totalAmount: 300, // Assuming totalAmount corresponds to price
@@ -78,7 +83,8 @@ export const invoices: Array<InvoiceModel> = [
     services: [testService], // Assuming this is an array of ser
   },
   {
-    id: 'PRO1247',
+    id: 6,
+    invoiceId: 'PRO1247',
     date: '2024-02-24',
     company: 'Company 2',
     totalAmount: 300, // Assuming totalAmount corresponds to price
@@ -89,7 +95,8 @@ export const invoices: Array<InvoiceModel> = [
     services: [testService], // Assuming this is an array of ser
   },
   {
-    id: 'PRO173',
+    id: 7,
+    invoiceId: 'PRO173',
     date: '2024-02-24',
     company: 'Company 2',
     totalAmount: 300, // Assuming totalAmount corresponds to price
@@ -100,7 +107,8 @@ export const invoices: Array<InvoiceModel> = [
     services: [testService], // Assuming this is an array of ser
   },
   {
-    id: 'PRO18124',
+    id: 8,
+    invoiceId: 'PRO18124',
     date: '2024-02-24',
     company: 'Company 2',
     totalAmount: 300, // Assuming totalAmount corresponds to price
@@ -111,7 +119,8 @@ export const invoices: Array<InvoiceModel> = [
     services: [testService], // Assuming this is an array of ser
   },
   {
-    id: 'PRO103',
+    id: 9,
+    invoiceId: 'PRO103',
     date: '2024-02-24',
     company: 'Company 2',
     totalAmount: 300, // Assuming totalAmount corresponds to price
@@ -122,7 +131,8 @@ export const invoices: Array<InvoiceModel> = [
     services: [testService], // Assuming this is an array of ser
   },
   {
-    id: 'PRO183',
+    id: 10,
+    invoiceId: 'PRO183',
     date: '2024-02-24',
     company: 'Company 2',
     totalAmount: 300, // Assuming totalAmount corresponds to price
@@ -133,7 +143,8 @@ export const invoices: Array<InvoiceModel> = [
     services: [testService], // Assuming this is an array of ser
   },
   {
-    id: 'PRO153',
+    id: 11,
+    invoiceId: 'PRO153',
     date: '2024-02-24',
     company: 'Company 2',
     totalAmount: 300, // Assuming totalAmount corresponds to price
@@ -144,7 +155,8 @@ export const invoices: Array<InvoiceModel> = [
     services: [testService], // Assuming this is an array of ser
   },
   {
-    id: 'PRO1623',
+    id: 12,
+    invoiceId: 'PRO1623',
     date: '2024-02-24',
     company: 'Company 2',
     totalAmount: 300, // Assuming totalAmount corresponds to price
@@ -155,7 +167,8 @@ export const invoices: Array<InvoiceModel> = [
     services: [testService], // Assuming this is an array of ser
   },
   {
-    id: 'PRO1213',
+    id: 13,
+    invoiceId: 'PRO1213',
     date: '2024-02-24',
     company: 'Company 2',
     totalAmount: 300, // Assuming totalAmount corresponds to price
@@ -166,7 +179,8 @@ export const invoices: Array<InvoiceModel> = [
     services: [testService], // Assuming this is an array of ser
   },
   {
-    id: 'PRO1233',
+    id: 14,
+    invoiceId: 'PRO1233',
     date: '2024-02-24',
     company: 'Company 2',
     totalAmount: 300, // Assuming totalAmount corresponds to price
@@ -177,7 +191,8 @@ export const invoices: Array<InvoiceModel> = [
     services: [testService], // Assuming this is an array of ser
   },
   {
-    id: 'PRO124',
+    id: 15,
+    invoiceId: 'PRO124',
     date: '2024-02-24',
     company: 'Company 2',
     totalAmount: 300, // Assuming totalAmount corresponds to price

--- a/server/src/options/client.ts
+++ b/server/src/options/client.ts
@@ -1,0 +1,94 @@
+import {
+  deleteClient,
+  getClient,
+  getClients,
+  postClient,
+  updateClient,
+} from '../controllers/client';
+import { ClientModel } from '../types/models/client';
+
+const Client = {
+  type: 'object',
+  properties: <Record<keyof ClientModel, { type: string }>>{
+    id: { type: 'number' },
+    address: { type: 'string' },
+    businessNumber: { type: 'string' },
+    businessType: { type: 'string' },
+    email: { type: 'string' },
+    name: { type: 'string' },
+    type: { type: 'string' },
+  },
+};
+
+export const getClientsOptions = {
+  schema: {
+    response: {
+      200: {
+        type: 'array',
+        clients: Client,
+      },
+    },
+  },
+  handler: getClients,
+};
+
+export const getClientOptions = {
+  schema: {
+    response: {
+      200: Client,
+    },
+  },
+  handler: getClient,
+};
+
+export const postClientOptions = {
+  schema: {
+    body: {
+      type: 'object',
+      required: <Array<keyof ClientModel>>[
+        'id',
+        'name',
+        'businessNumber',
+        'businessType',
+        'address',
+        'type',
+      ],
+      properties: <Record<keyof ClientModel, { type: string }>>{
+        id: { type: 'string' },
+        name: { type: 'string' },
+        businessNumber: { type: 'string' },
+        businessType: { type: 'string' },
+        address: { type: 'string' },
+        type: { type: 'string' },
+        email: { type: 'string' },
+      },
+    },
+    response: {
+      201: Client,
+    },
+  },
+  handler: postClient,
+};
+
+export const updateClientOptions = {
+  schema: {
+    response: {
+      200: Client,
+    },
+  },
+  handler: updateClient,
+};
+
+export const deleteClientOptions = {
+  schema: {
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          message: { type: 'string' },
+        },
+      },
+    },
+  },
+  handler: deleteClient,
+};

--- a/server/src/options/invoice.ts
+++ b/server/src/options/invoice.ts
@@ -17,8 +17,7 @@ const Receiver = {
     address: { type: 'string' },
     businessNumber: { type: 'string' },
     email: { type: 'string' },
-    firstName: { type: 'string' },
-    lastName: { type: 'string' },
+    name: { type: 'string' },
     type: { type: 'string' },
   },
 };
@@ -43,7 +42,8 @@ const Invoice = {
       { type: string } | typeof Receiver | typeof Service
     >
   >{
-    id: { type: 'string' },
+    id: { type: 'number' },
+    invoiceId: { type: 'string' },
     company: { type: 'string' },
     date: { type: 'string' },
     dueDate: { type: 'string' },

--- a/server/src/routes/client.ts
+++ b/server/src/routes/client.ts
@@ -1,0 +1,23 @@
+import {
+  getClientsOptions,
+  getClientOptions,
+  postClientOptions,
+  updateClientOptions,
+  deleteClientOptions,
+} from '../options/client';
+
+const clientRoutes = (fastify, _options, done) => {
+  fastify.get('/api/clients', getClientsOptions);
+
+  fastify.get('/api/clients/:id', getClientOptions);
+
+  fastify.post('/api/clients', postClientOptions);
+
+  fastify.put('/api/clients/:id', updateClientOptions);
+
+  fastify.delete('/api/clients/:id', deleteClientOptions);
+
+  done();
+};
+
+export default clientRoutes;

--- a/server/src/types/dtos/client.ts
+++ b/server/src/types/dtos/client.ts
@@ -1,0 +1,13 @@
+type InvoicePartyBusinessType = 'business' | 'individual';
+
+type InvoicePartyType = 'sender' | 'receiver';
+
+export type ClientDto = {
+  id: number;
+  name: string;
+  type: InvoicePartyType;
+  business_type: InvoicePartyBusinessType;
+  business_number: string;
+  address: string;
+  email?: string;
+};

--- a/server/src/types/dtos/invoice.ts
+++ b/server/src/types/dtos/invoice.ts
@@ -17,7 +17,8 @@ type InvoiceService = {
 type InvoiceStatus = 'paid' | 'pending' | 'canceled';
 
 export type InvoiceDto = {
-  id: string;
+  id: number;
+  invoice_id: string;
   date: string;
   company: string;
   sender: InvoiceParty;

--- a/server/src/types/dtos/invoice.ts
+++ b/server/src/types/dtos/invoice.ts
@@ -1,6 +1,5 @@
 type InvoiceParty = {
-  first_name: string;
-  last_name: string;
+  name: string;
   type: string;
   business_number: string;
   address: string;

--- a/server/src/types/models/client.ts
+++ b/server/src/types/models/client.ts
@@ -1,4 +1,4 @@
-import { InvoicePartyBusinessType, InvoicePartyType } from './invoice';
+import { InvoicePartyBusinessType, InvoicePartyType } from '../models/invoice';
 
 export type ClientModel = {
   id: number;

--- a/server/src/types/models/invoice.ts
+++ b/server/src/types/models/invoice.ts
@@ -15,7 +15,8 @@ export type InvoiceService = {
 };
 
 export type InvoiceModel = {
-  id: string;
+  id: number;
+  invoiceId: string;
   date: string;
   company: string;
   sender: InvoiceParty;

--- a/server/src/types/models/invoice.ts
+++ b/server/src/types/models/invoice.ts
@@ -1,6 +1,5 @@
 export type InvoiceParty = {
-  firstName: string;
-  lastName: string;
+  name: string;
   type: string;
   businessNumber: string;
   address: string;
@@ -28,3 +27,7 @@ export type InvoiceModel = {
 };
 
 export type InvoiceStatus = 'paid' | 'pending' | 'canceled';
+
+export type InvoicePartyBusinessType = 'business' | 'individual';
+
+export type InvoicePartyType = 'sender' | 'receiver';

--- a/server/src/utils/transformers.ts
+++ b/server/src/utils/transformers.ts
@@ -7,6 +7,7 @@ export const transformInvoiceDto = (invoiceDto: InvoiceDto): InvoiceModel => {
     date,
     due_date,
     id,
+    invoice_id,
     receiver,
     sender,
     services,
@@ -16,6 +17,7 @@ export const transformInvoiceDto = (invoiceDto: InvoiceDto): InvoiceModel => {
 
   return {
     id,
+    invoiceId: invoice_id,
     company,
     date,
     dueDate: due_date,

--- a/server/src/utils/transformers.ts
+++ b/server/src/utils/transformers.ts
@@ -1,4 +1,6 @@
+import { ClientDto } from '../types/dtos/client';
 import { InvoiceDto } from '../types/dtos/invoice';
+import { ClientModel } from '../types/models/client';
 import { InvoiceModel } from '../types/models/invoice';
 
 export const transformInvoiceDto = (invoiceDto: InvoiceDto): InvoiceModel => {
@@ -24,21 +26,34 @@ export const transformInvoiceDto = (invoiceDto: InvoiceDto): InvoiceModel => {
     receiver: {
       address: receiver.address,
       businessNumber: receiver.business_number,
-      firstName: receiver.first_name,
-      lastName: receiver.last_name,
+      name: receiver.name,
       type: receiver.type,
       email: receiver.email,
     },
     sender: {
       address: sender.address,
       businessNumber: sender.business_number,
-      firstName: sender.first_name,
-      lastName: sender.last_name,
+      name: sender.name,
       type: sender.type,
       email: sender.email,
     },
     services,
     status,
     totalAmount: total_amount,
+  };
+};
+
+export const transformClientDto = (clientDto: ClientDto): ClientModel => {
+  const { id, name, business_type, business_number, address, type, email } =
+    clientDto;
+
+  return {
+    id,
+    name,
+    businessType: business_type,
+    businessNumber: business_number,
+    address,
+    type,
+    email,
   };
 };


### PR DESCRIPTION
## Overview

In this PR I have created endpoints for `clients` on the server, as well as populated the `ClientsPage` with a new component called `ClientsSection` which consists of the section content, a `ClientSectionTopContent` component and a `ClientSectionBottomContent` component.

The structure is similar to that of the `InvoiceTable` component, except in this PR I have made a custom implementation in terms of the filtering and searching logic, also, instead of displaying data in a table, I'm displaying it in editable/removable cards through the newly created `InvoicePartyCard` component.

## Additional changes
The next steps will be integrating the database, therefore I have modified the data types for the invoice slightly: 

Previously, the id field was meant for showing the invoice series and number, I renamed it to `invoiceId`, since the `id` field will be automatically created in the database. Also, the `firstName` and `lastName` fields have been combined into one `name` field because the invoice party can be both a person and a company, and a company, obviously, does not have a last name.